### PR TITLE
Add interactive random word web page

### DIFF
--- a/random_word.html
+++ b/random_word.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Random Word Generator</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at top, #f0f4ff, #d9e2ec 40%, #bcccdc);
+    }
+
+    .card {
+      background: rgba(255, 255, 255, 0.85);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+      border-radius: 20px;
+      padding: 48px 56px;
+      text-align: center;
+      backdrop-filter: blur(6px);
+      max-width: 480px;
+    }
+
+    h1 {
+      margin: 0 0 32px;
+      font-size: clamp(2rem, 3vw + 1rem, 3.5rem);
+      color: #1f2933;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+
+    .word {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 240px;
+      padding: 24px 36px;
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      font-weight: 700;
+      color: #102a43;
+      background: linear-gradient(135deg, #63b3ed, #3182ce);
+      border-radius: 18px;
+      cursor: pointer;
+      user-select: none;
+      transition: transform 150ms ease, box-shadow 150ms ease;
+      box-shadow: 0 10px 25px rgba(49, 130, 206, 0.25);
+    }
+
+    .word:hover,
+    .word:focus-visible {
+      transform: translateY(-4px);
+      box-shadow: 0 18px 35px rgba(49, 130, 206, 0.35);
+    }
+
+    .word:active {
+      transform: translateY(0);
+    }
+
+    .hint {
+      margin-top: 24px;
+      font-size: 1rem;
+      color: #52606d;
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding: 24px;
+      }
+
+      .card {
+        padding: 36px 32px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Tap the Word</h1>
+    <div id="word" class="word" role="button" tabindex="0" aria-label="Random word"></div>
+    <p class="hint">点击单词以生成新的单词</p>
+  </main>
+  <script>
+    const wordElement = document.getElementById("word");
+    const WORDS = [
+      "Aurora",
+      "Cascade",
+      "Harmony",
+      "Momentum",
+      "Nebula",
+      "Odyssey",
+      "Pulse",
+      "Quasar",
+      "Serenity",
+      "Velocity",
+      "Wonder",
+      "Zenith"
+    ];
+
+    const getRandomWord = () => WORDS[Math.floor(Math.random() * WORDS.length)];
+
+    const updateWord = () => {
+      const nextWord = getRandomWord();
+      wordElement.textContent = nextWord;
+    };
+
+    wordElement.addEventListener("click", updateWord);
+    wordElement.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        updateWord();
+      }
+    });
+
+    updateWord();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page that displays a random word on load
- allow users to click or press enter/space to reveal a new random word
- include accessible focus handling and polished styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d423ac0f408325990550c3fc0f3ac6